### PR TITLE
AttributeError: module 'numpy' has no attribute 'float'

### DIFF
--- a/pytebis/tebis.py
+++ b/pytebis/tebis.py
@@ -463,9 +463,9 @@ class Tebis():
                         intInc = np.int64(result[m_intPos])
                         m_intPos += 1
                     elif np.issubdtype(resultarr[resultarr.dtype.names[x]].dtype, np.floating):
-                        intStart = np.float(result[m_intPos])
+                        intStart = np.float64(result[m_intPos])
                         m_intPos += 1
-                        intInc = np.float(result[m_intPos])
+                        intInc = np.float64(result[m_intPos])
                         m_intPos += 1
                     resultarr[resultarr.dtype.names[x]][y:(y + intStackLen)] = np.linspace(
                         intStart, intStart + (intStackLen * intInc) - intInc, num=intStackLen)
@@ -519,7 +519,7 @@ class Tebis():
                     find = np.nonzero(value == '')
                     for res in find[0]:
                         value[res] = np.NaN
-                    value = np.array(value, dtype=np.float)
+                    value = np.array(value, dtype=np.float64)
                 except ValueError as e:
                     None
             else:

--- a/pytebis/tebis.py
+++ b/pytebis/tebis.py
@@ -359,7 +359,7 @@ class Tebis():
 
     def loadVmstsFromSocket(self):
         array = np.dtype([('ID', (np.int64)), ('MSTName', np.unicode_, 100), ('UNIT', 'U10'), (
-            'MSTDesc', np.unicode_, 255), ('Rate', (np.int)), ('Formula', np.unicode_, 255), ('refresh', (np.int))])
+            'MSTDesc', np.unicode_, 255), ('Rate', (np.int64)), ('Formula', np.unicode_, 255), ('refresh', (np.int64))])
         data = self.getConfigData("VMsts", array)
         return data
 


### PR DESCRIPTION
Issue: #2 

Make code compatible with newest numpy version.

- [x] tested with code changes. Functionality in place and compatibility restored with newest numpy version (v1.24.3)

**AttributeError**: module 'numpy' has no attribute 'float'

**Changes**:
- np.float to np.float64 in tebis.py
- np.int to np.int64 in tebis.py